### PR TITLE
Align WebMCP imperative API with Document-scoped modelContext

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `CONTRIBUTING.md` — DCO sign-off now distinguishes between CC BY 4.0 (spec/schemas/examples/docs) and Apache 2.0 (code/tooling/CI) contributions
 - `CONTRIBUTING.md` — corrected GitHub→GitHub and Pull Request→Pull Request terminology
 - `.github/ISSUE_TEMPLATE/rfc-proposal.md` — added comment-period and resolution tracking fields
+- WebMCP imperative API — `navigator.modelContext` → `document.modelContext` across spec, README, and proposal, tracking the WebML CG decision to scope tools to the active `Document` ([webmcp#173](https://github.com/webmachinelearning/webmcp/issues/173), [crbug 515330187](https://issues.chromium.org/issues/515330187))
 
 ## [0.1] - 2026-03-06
 

--- a/README.md
+++ b/README.md
@@ -102,8 +102,8 @@ OJCP supports [WebMCP](https://developer.chrome.com/docs/ai/webmcp) (Chrome 146+
 **Imperative API** — Register OJCP tools directly on your careers page:
 
 ```js
-if ("modelContext" in navigator) {
-  navigator.modelContext.registerTool({
+if ("modelContext" in document) {
+  document.modelContext.registerTool({
     name: "search_jobs",
     description: "Search open roles at Acme Corp.",
     inputSchema: {
@@ -194,7 +194,7 @@ When the agent applies on behalf of a candidate, OJCP enforces a consent gate be
 | Standard | Relationship |
 |---|---|
 | MCP | OJCP tools are valid MCP tools — callable by any MCP client |
-| WebMCP | Imperative API (`navigator.modelContext.registerTool()`) and declarative API (form `toolname`/`tooldescription` attributes) |
+| WebMCP | Imperative API (`document.modelContext.registerTool()`) and declarative API (form `toolname`/`tooldescription` attributes) |
 | schema.org/JobPosting | OJCP extends it; existing structured data stays valid |
 | OpenAPI 3.1 | REST endpoints documented in OpenAPI; registry validates conformance |
 | Indeed / Zip XML Feeds | OJCP layers over existing feeds via adapter; no replacement required |

--- a/docs/proposal.md
+++ b/docs/proposal.md
@@ -75,7 +75,7 @@ That experience informs this proposal, but the standard must be shaped by the br
 
 1. **Agent-native, not human-last.** OJCP is designed first for LLM tool-use. Human readability is a secondary concern.
 2. **MCP-interoperable.** Job Tools exposed via OJCP should be callable by any MCP-compatible agent with no translation layer.
-3. **WebMCP-compatible.** For browser-native agents (Apple Intelligence, browser assistants), OJCP tools can be registered via `navigator.modelContext` (imperative API) or annotated in HTML forms (declarative API).
+3. **WebMCP-compatible.** For browser-native agents (Apple Intelligence, browser assistants), OJCP tools can be registered via `document.modelContext` (imperative API) or annotated in HTML forms (declarative API).
 4. **Schema.org backward-compatible.** Existing `JobPosting` schema.org markup is preserved and extended, not replaced.
 5. **Privacy-preserving.** Candidate context passed to Job Tools must be explicitly consented to and minimized by default. Identity verification proofs carry no PII — only cryptographic attestations.
 6. **Employer-controlled.** Employers retain the ability to restrict, rate-limit, audit agent interactions, and require identity verification on any apply path.
@@ -274,7 +274,7 @@ As AI agents begin submitting applications on behalf of candidates, employers in
 
 For browser-native agents, providers can register OJCP tools via two complementary WebMCP APIs:
 
-**Imperative API** — Register tools programmatically via `navigator.modelContext.registerTool()`. Providers should unregister tools when they are no longer applicable to the current page.
+**Imperative API** — Register tools programmatically via `document.modelContext.registerTool()`. Providers should unregister tools when they are no longer applicable to the current page.
 
 **Declarative API** — Annotate HTML forms with `toolname`, `tooldescription`, and `toolparamdescription` attributes. The browser translates annotated forms into structured tools. Providers detect agent submissions via `SubmitEvent.agentInvoked` and return structured results via `SubmitEvent.respondWith()`.
 
@@ -323,7 +323,7 @@ This enables job boards and aggregators to track referral value without baking a
 | Standard | Relationship |
 |---|---|
 | **MCP (Model Context Protocol)** | OJCP tools are valid MCP tools. Any MCP client can call OJCP-compliant endpoints. |
-| **WebMCP** | OJCP tools can be registered via the imperative API (`navigator.modelContext.registerTool()`) or the declarative API (`toolname`/`tooldescription` form attributes) for browser agent access. |
+| **WebMCP** | OJCP tools can be registered via the imperative API (`document.modelContext.registerTool()`) or the declarative API (`toolname`/`tooldescription` form attributes) for browser agent access. |
 | **schema.org/JobPosting** | OJCP's `JobPosting` extends schema.org. Existing structured data remains valid; OJCP adds agent-specific fields. |
 | **JSON Feed / RSS** | OJCP is not a syndication format — it is an action-oriented, tool-native interface. Legacy feeds remain complementary for SEO. |
 | **Indeed XML Feed / ZipRecruiter API** | OJCP can be layered over existing job board APIs via an adapter. No replacement required. |

--- a/spec/ojcp-v0.1.bs
+++ b/spec/ojcp-v0.1.bs
@@ -1547,12 +1547,12 @@ The provider validates the Checkr proof using the standard claim validation proc
 
 ## Imperative API ## {#webmcp-imperative}
 
-Providers MAY register OJCP tools programmatically via `navigator.modelContext.registerTool()`:
+Providers MAY register OJCP tools programmatically via `document.modelContext.registerTool()`:
 
 <div class="example">
 ```js
-if ("modelContext" in navigator) {
-  navigator.modelContext.registerTool({
+if ("modelContext" in document) {
+  document.modelContext.registerTool({
     name: "search_jobs",
     description: "Search for open job opportunities. Pass a natural language query.",
     inputSchema: {
@@ -1584,7 +1584,11 @@ if ("modelContext" in navigator) {
 ```
 </div>
 
-Providers SHOULD call `navigator.modelContext.unregisterTool(name)` to remove tools when they are no longer applicable to the current page state.
+Providers SHOULD call `document.modelContext.unregisterTool(name)` to remove tools when they are no longer applicable to the current page state.
+
+<div class="note">
+The `modelContext` namespace is scoped to the active [=document=]. Earlier WebMCP drafts exposed it on `navigator`; following [WebML CG](https://www.w3.org/community/webmachinelearning/) guidance ([webmcp#173](https://github.com/webmachinelearning/webmcp/issues/173)), it now lives on `document` so that registered tools are not inadvertently shared across same-`Window` navigations. As of this writing the move is reflected in the WebMCP draft but not yet shipped in Chromium ([crbug 515330187](https://issues.chromium.org/issues/515330187)); implementers targeting current Chromium builds should feature-detect both locations during the transition.
+</div>
 
 ## Declarative API ## {#webmcp-declarative}
 
@@ -1739,7 +1743,7 @@ Agents MUST NOT retry before the indicated `Retry-After` / `retry_after_seconds`
   </thead>
   <tbody>
     <tr><td>**MCP**</td><td>OJCP tools are valid MCP tools. Any MCP client can call OJCP-compliant endpoints.</td></tr>
-    <tr><td>**WebMCP**</td><td>OJCP tools can be registered via the imperative API (`navigator.modelContext.registerTool()`) or the declarative API (`toolname`/`tooldescription` form attributes) for browser agent access.</td></tr>
+    <tr><td>**WebMCP**</td><td>OJCP tools can be registered via the imperative API (`document.modelContext.registerTool()`) or the declarative API (`toolname`/`tooldescription` form attributes) for browser agent access.</td></tr>
     <tr><td>**schema.org/JobPosting**</td><td>OJCP's JobPosting extends schema.org. Existing structured data remains valid.</td></tr>
     <tr><td>**OpenAPI 3.1**</td><td>OJCP REST endpoints SHOULD be documented with OpenAPI 3.1.</td></tr>
     <tr><td>**Indeed XML / ZipRecruiter API**</td><td>OJCP can be layered over existing feeds via adapter.</td></tr>


### PR DESCRIPTION
The WebML CG decided to scope WebMCP tools to the active Document rather than the Window/Navigator, so that registered tools are not inadvertently shared across same-Window navigations (e.g. navigating away from the initial about:blank document).

Update the imperative API from navigator.modelContext to document.modelContext across the spec, README, and proposal, including the feature-detection guard, and add an informative note explaining the rationale and the current Chromium implementation gap.

No protocol surface changes: tools, schemas, the manifest, apply-path types, and the ojcp_version wire value are unaffected, so VERSION / ojcp_version stay at 0.1. Logged under CHANGELOG [Unreleased].

Refs: ojcp-org/ojcp#1, webmachinelearning/webmcp#173, crbug 515330187

## Summary

<!-- What does this PR do? One or two sentences. -->

## Type of change

- [x] Spec prose (editorial clarification, typo fix)
- [ ] Schema change (new or modified JSON Schema)
- [ ] New tool or field (RFC required)
- [x] Example or documentation
- [ ] CI / build infrastructure
- [ ] Other: <!-- describe -->

## Checklist

- [x] `bikeshed spec` compiles without errors
- [x] All JSON files parse cleanly
- [x] Examples validate against their schemas (`ajv validate`)
- [x] Updated `docs/proposal.md` if spec prose changed
- [x] Updated `CHANGELOG.md`
- [x] Commits are signed off (`Signed-off-by:` per DCO)

## RFC

<!-- If this is a substantive change (new tool, schema modification, apply path type, security model change), link the RFC issue or describe the motivation. -->

N/A — editorial only
