### PR TITLE
Add FoundRole as Implementing adopter

### DIFF
--- a/ADOPTERS.md
+++ b/ADOPTERS.md
@@ -29,6 +29,7 @@ If your organization is using OJCP at any tier, please open a PR to add yourself
 | Organization | Implementation | Status | Since |
 |--------------|----------------|--------|-------|
 | Recruitics | Reference provider at https://ojcp.dev | Live | 2026-02 |
+| FoundRole | Anonymous read-only provider at https://www.foundrole.com/ojcp/mcp | Live | 2026-08 |
 | _Add yours via PR_ | | | |
 
 ## Evaluating


### PR DESCRIPTION
Adds FoundRole to the Implementing tier.

We shipped an OJCP v0.1 provider:

- Manifest: https://www.foundrole.com/.well-known/ojcp.json
- Endpoint: https://www.foundrole.com/ojcp/mcp (anonymous, no auth)
- Tools: `search_jobs`, `get_job_detail`

The endpoint returns posting facts — title, employer, date, location, employment type, remote policy and an apply path — and validates against `manifest.json`, `responses/search-jobs.json` and `responses/job-detail.json` as published. Applications aren't submitted through it (`supports_agent_submission: false`).

One note that might be useful for the next implementer, since we're the first outside the reference provider: everything validated against the published schemas with no changes needed on our side. The one snag was that `$id`s resolve to `https://ojcp.dev/schemas/v0.1/...` while the repo lays the files out under `schemas/responses/` and `schemas/tools/`, so a validator needs a resolver mapping those paths — worth a line in the docs if others hit it.

Per CONTRIBUTING, our preferred affiliation for the Acknowledgements section is simply "FoundRole".